### PR TITLE
New options --dry-run and --prune-all

### DIFF
--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -36,4 +36,4 @@ jobs:
             - name: Build
               run: pnpm build
             - name: Test
-              run: pnpm test --tempdir="${RUNNER_TEMP}"
+              run: pnpm test --ci=true --tempdir="${RUNNER_TEMP}"

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -36,4 +36,4 @@ jobs:
             - name: Build
               run: pnpm build
             - name: Test
-              run: pnpm test --tempdir={{ vars.RUNNER_TEMP}}
+              run: pnpm test --tempdir="${RUNNER_TEMP}"

--- a/.github/workflows/lint-and-tests.yml
+++ b/.github/workflows/lint-and-tests.yml
@@ -35,5 +35,5 @@ jobs:
               run: pnpm lint
             - name: Build
               run: pnpm build
-            # - name: Test
-              # run: pnpm test
+            - name: Test
+              run: pnpm test --tempdir={{ vars.RUNNER_TEMP}}

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Addresses questions, like:
 - [Remove tracking branches no longer on remote](https://stackoverflow.com/questions/7726949/remove-tracking-branches-no-longer-on-remote)
 - [How to prune local tracking branches that do not exist on remote anymore?](https://stackoverflow.com/questions/13064613/how-to-prune-local-tracking-branches-that-do-not-exist-on-remote-anymore/30494276#30494276)
 
-![](https://github.com/nemisj/git-removed-branches/blob/master/usage.gif)
+![](https://github.com/patik/git-removed-branches/blob/master/usage.gif)
 
 ## Why?
 
@@ -92,10 +92,14 @@ git removed-branches --version
 
 ## Troubleshooting:
 
-If you encounter error `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` it is possible that your repository contains too much branches, more then 3382. ( see [discussion](https://github.com/nemisj/git-removed-branches/issues/11) )
+If you encounter error `ERR_CHILD_PROCESS_STDIO_MAXBUFFER` it is possible that your repository contains too much branches, more then 3382. ( see [discussion](https://github.com/patik/git-removed-branches/issues/11) )
 
 You can fix this, by specifying NODE_MAX_BUFFER environment variable, like:
 
 ```
 NODE_MAX_BUFFER=1048576 git removed-branches
 ```
+
+## Credit
+
+Forked from [git-removed-branches](https://github.com/nemisj/git-removed-branches) by [Maks Nemisj](https://github.com/nemisj) @nemisj

--- a/package.json
+++ b/package.json
@@ -5,30 +5,30 @@
         "node": ">=18"
     },
     "description": "Git: Remove local branches which are no longer available on the remote",
-    "main": "index.js",
+    "main": "dist/index.js",
     "type": "module",
     "preferGlobal": true,
     "bin": {
         "git-removed-branches": "dis/index.js"
     },
     "scripts": {
-        "test": "tsx ./src/test.ts",
-        "start": "tsx ./src/index.ts",
         "build": "tsc",
+        "start": "tsx ./src/index.ts",
+        "test": "pnpm run build && tsx ./src/test.ts",
+        "lint": "tsc --noEmit && pnpm run format && eslint .",
         "format": "prettier --write --list-different .",
-        "check-format": "prettier --check --list-different .",
-        "lint": "eslint . && tsc --noEmit && pnpm run format"
+        "check-format": "prettier --check --list-different ."
     },
     "repository": {
         "type": "git",
-        "url": "https://github.com/nemisj/git-removed-branches.git"
+        "url": "https://github.com/patik/git-removed-branches.git"
     },
-    "author": "Maks Nemisj",
+    "author": "Craig Patik",
     "license": "MIT",
     "bugs": {
-        "url": "https://github.com/nemisj/git-removed-branches/issues"
+        "url": "https://github.com/patik/git-removed-branches/issues"
     },
-    "homepage": "https://github.com/nemisj/git-removed-branches",
+    "homepage": "https://github.com/patik/git-removed-branches",
     "dependencies": {
         "minimist": "^1.2.8"
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,14 +74,16 @@ const program = async () => {
             exit(0)
         }
 
-        const userSelectedBranches = argv['prune-all']
+        const pruneAll = argv['prune-all']
+
+        const userSelectedBranches = pruneAll
             ? allStaleBranches
             : await checkbox({
                   message: 'Select branches to remove',
                   pageSize: 40,
                   choices: allStaleBranches.map((value) => ({ value })),
               })
-        const confirmAnswer = argv['prune-all']
+        const confirmAnswer = pruneAll
             ? true
             : await confirm({
                   message: `Are you sure you want to remove all ${userSelectedBranches.length} branche${userSelectedBranches.length !== 1 ? 's' : ''}?`,
@@ -108,7 +110,7 @@ const program = async () => {
                 process.stderr.write((err.stack || err) + '\r\n')
             }
         }
-        // exit(1)
+        exit(1)
     }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env -S node
 
+import { checkbox, confirm } from '@inquirer/prompts'
 import minimist from 'minimist'
 import { exec } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
 import { exit } from 'node:process'
 import FindStale from './lib/find-stale.js'
-import { checkbox, confirm } from '@inquirer/prompts'
 
 process.on('uncaughtException', (error) => {
     if (error instanceof Error && error.name === 'ExitPromptError') {
@@ -29,20 +29,22 @@ try {
 
 const argv = minimist(process.argv, {
     string: 'remote',
-    boolean: ['prune', 'force', 'version'],
-    alias: { p: 'prune', f: 'force', r: 'remote' },
+    boolean: ['dry-run', 'prune-all', 'force', 'version'],
+    alias: { d: 'dry-run', p: 'prune-all', f: 'force', r: 'remote' },
     default: {
         remote: 'origin',
         force: false,
     },
 })
 
-const options = ['version', 'prune', 'p', 'force', 'f', 'remote', 'r', '_']
+const options = ['version', 'dry-run', 'd', 'prune-all', 'p', 'force', 'f', 'remote', 'r', '_']
 const hasInvalidParams: boolean = Object.keys(argv).some((name) => options.indexOf(name) == -1)
 
-;(async () => {
+const program = async () => {
     if (hasInvalidParams) {
-        console.info('Usage: git removed-branches [-p|--prune] [-f|--force] [-r|--remote <remote>] [--version]')
+        console.info(
+            'Usage: git removed-branches [-d|--dry-run] [-p|--prune-all] [-f|--force] [-r|--remote <remote>] [--version]',
+        )
         return
     }
 
@@ -52,7 +54,7 @@ const hasInvalidParams: boolean = Object.keys(argv).some((name) => options.index
     }
 
     const obj = new FindStale({
-        remove: argv.prune,
+        remove: !argv['dry-run'],
         force: argv.force,
         remote: argv.remote,
     })
@@ -65,29 +67,34 @@ const hasInvalidParams: boolean = Object.keys(argv).some((name) => options.index
                 exit(1)
             }
         })
-        const options = await obj.findStaleBranches()
+        const allStaleBranches = await obj.findStaleBranches()
 
-        if (options.length === 0) {
+        if (allStaleBranches.length === 0) {
             console.info('No stale branches were found')
             exit(0)
         }
 
-        const answer = await checkbox({
-            message: 'Select branches to delete',
-            pageSize: 40,
-            choices: options.map((value) => ({ value })),
-        })
-
-        const confirmAnswer = await confirm({
-            message: `Are you sure you want to delete all ${answer.length} branche${answer.length !== 1 ? 's' : ''}?`,
-            default: false,
-        })
+        const userSelectedBranches = argv['prune-all']
+            ? allStaleBranches
+            : await checkbox({
+                  message: 'Select branches to remove',
+                  pageSize: 40,
+                  choices: allStaleBranches.map((value) => ({ value })),
+              })
+        const confirmAnswer = argv['prune-all']
+            ? true
+            : await confirm({
+                  message: `Are you sure you want to remove all ${userSelectedBranches.length} branche${userSelectedBranches.length !== 1 ? 's' : ''}?`,
+                  default: false,
+              })
 
         if (confirmAnswer) {
-            console.info(`Deleting ${answer.length} branches...`)
-            await obj.deleteBranches(answer)
+            console.info(
+                `Removing ${userSelectedBranches.length} branch${userSelectedBranches.length !== 1 ? 'es' : ''}...`,
+            )
+            await obj.deleteBranches(userSelectedBranches)
         } else {
-            console.info('No branches were deleted')
+            console.info('No branches were removed.')
         }
 
         exit(0)
@@ -101,6 +108,8 @@ const hasInvalidParams: boolean = Object.keys(argv).some((name) => options.index
                 process.stderr.write((err.stack || err) + '\r\n')
             }
         }
-        exit(1)
+        // exit(1)
     }
-})()
+}
+
+program()

--- a/src/lib/find-stale.ts
+++ b/src/lib/find-stale.ts
@@ -27,7 +27,7 @@ export default class FindStale {
         this.noConnection = false
     }
 
-    async preprocess(verbose = false) {
+    async preprocess() {
         // cached branches from the remote
         this.remoteBranches = []
 
@@ -44,7 +44,7 @@ export default class FindStale {
         // this will become true
         this.noConnection = false
 
-        await this.findLiveBranches(verbose)
+        await this.findLiveBranches()
         await this.findLocalBranches()
         await this.findRemoteBranches()
         await this.analyzeLiveAndCache()
@@ -82,7 +82,7 @@ export default class FindStale {
     // to find branches which are still available on the remote
     // and store them in liveBranches state
     //
-    async findLiveBranches(verbose = false) {
+    async findLiveBranches() {
         if (this.remote === '') {
             const e = new Error('Remote is empty. Please specify remote with -r parameter')
             // @ts-expect-error - this is a custom error code
@@ -99,13 +99,11 @@ export default class FindStale {
         })
 
         if (!hasRemote) {
-            if (verbose) {
-                console.log(
-                    `WARNING: Unable to find remote "${
-                        this.remote
-                    }".\r\n\r\nAvailable remotes are:\r\n${remotesStr?.toString()}`,
-                )
-            }
+            console.log(
+                `WARNING: Unable to find remote "${
+                    this.remote
+                }".\r\n\r\nAvailable remotes are:\r\n${remotesStr?.toString()}`,
+            )
             this.noConnection = true
             return
         }
@@ -205,13 +203,13 @@ export default class FindStale {
         return this.staleBranches
     }
 
-    async deleteBranches(branchesToDelete: Array<string>, verbose = false) {
+    async deleteBranches(branchesToDelete: Array<string>) {
         if (!branchesToDelete.length) {
             console.info('No remotely removed branches found')
             return
         }
 
-        if (!this.remove && verbose) {
+        if (!this.remove) {
             console.log('Found remotely removed branches:')
         }
 
@@ -219,13 +217,11 @@ export default class FindStale {
 
         for (const branchName of branchesToDelete) {
             if (this.remove) {
-                if (verbose) {
-                    console.info('')
-                    console.info(`Removing "${branchName}"`)
-                }
+                console.info('')
+                console.info(`Removing "${branchName}"`)
 
-                const dFlag = this.force ? '-D' : '-d'
                 try {
+                    const dFlag = this.force ? '-D' : '-d'
                     const out = await stdout(`git branch ${dFlag} "${branchName}"`)
                     console.info(out)
                 } catch (err) {
@@ -234,30 +230,24 @@ export default class FindStale {
                     broken.push(branchName)
                 }
             } else {
-                if (verbose) {
-                    console.info(`  - ${branchName}`)
-                }
+                console.info(`  - ${branchName}`)
             }
-        }
-
-        if (!verbose) {
-            return []
         }
 
         console.info('')
 
-        if (broken.length) {
+        if (broken.length > 0) {
             // unable to remove branch
-            console.info('Not all branches are removed:')
+            console.info('Not all branches were removed:')
             broken.forEach((name) => {
                 console.info('  - ' + name)
             })
             console.info('')
             console.info('INFO: To force removal use --force flag')
         } else if (this.remove) {
-            console.info('INFO: All branches are removed')
+            console.info('INFO: Branches were removed')
         } else {
-            console.info('INFO: To remove all founded branches use --prune flag')
+            console.info('INFO: To remove branches, don’t include the --dry-run flag')
         }
     }
 }

--- a/src/lib/stdout.ts
+++ b/src/lib/stdout.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process'
 
 /**
- * Returns stdout as a string from the given shell command
+ * Executes a command and returns stdout as a string
  */
 export async function stdout(command: string): Promise<string> {
     return new Promise((resolve, reject) => {

--- a/src/test.ts
+++ b/src/test.ts
@@ -13,7 +13,7 @@ const __dirname = path.dirname(__filename)
 
 const bin = path.join(__dirname, '../dist/index.js')
 
-const isCI = process.argv[3]?.split('=')[1] === 'true'
+const isCI = process.argv[2]?.split('=')[1] === 'true'
 
 console.log(`isCI: ${isCI}`)
 
@@ -22,14 +22,14 @@ let bareDir: string
 let workingDir: string
 
 const setup = () => {
-    if (!tempdir) {
-        const tmp = os.tmpdir()
-        tempdir = mkdtempSync(tmp + path.sep + 'git-removed-branches-')
-    }
-
     if (isCI) {
         child_process.execSync('git config --global user.email "you@example.com"', { cwd: tempdir })
         child_process.execSync('git config --global user.name "Your Name"', { cwd: tempdir })
+    }
+
+    if (!tempdir) {
+        const tmp = os.tmpdir()
+        tempdir = mkdtempSync(tmp + path.sep + 'git-removed-branches-')
     }
 
     bareDir = tempdir + path.sep + 'bare'

--- a/src/test.ts
+++ b/src/test.ts
@@ -1,5 +1,5 @@
 import assert from 'assert'
-import child_process from 'child_process'
+import child_process, { execFileSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
 import os from 'node:os'
 import path from 'node:path'
@@ -79,7 +79,9 @@ const setup = () => {
 }
 
 const test_nothing = () => {
-    const output = child_process.execFileSync('node', [bin], {
+    // console.log('workingDir: ', workingDir, '\n\n')
+    // console.log('bin: ', bin, '\n\n')
+    const output = execFileSync('node', [bin, '--prune-all', '--dry-run'], {
         cwd: workingDir,
         encoding: 'utf8',
     })
@@ -88,15 +90,15 @@ const test_nothing = () => {
 ${output}
 -------------------`)
 
-    assert.equal(output.indexOf('- chore/local-name-persistent'), -1)
-    assert.notEqual(output.indexOf('- chore/local-name-deleted'), -1)
-    assert.notEqual(output.indexOf('- #333-work'), -1)
-    assert.notEqual(output.indexOf('- feature/fast-forwarded'), -1)
-    assert.notEqual(output.indexOf('- no-ff'), -1)
+    assert.equal(output.indexOf(' chore/local-name-persistent'), -1)
+    assert.notEqual(output.indexOf(' chore/local-name-deleted'), -1)
+    assert.notEqual(output.indexOf(' #333-work'), -1)
+    assert.notEqual(output.indexOf(' feature/fast-forwarded'), -1)
+    assert.notEqual(output.indexOf(' no-ff'), -1)
 }
 
 const testing_prune = () => {
-    const output = child_process.execFileSync('node', [bin, '--prune'], {
+    const output = child_process.execFileSync('node', [bin, '--prune-all'], {
         cwd: workingDir,
         encoding: 'utf8',
     })
@@ -107,12 +109,12 @@ ${output}
 
     assert.notEqual(output.indexOf('Deleted branch #333-work'), -1)
     assert.notEqual(output.indexOf('Deleted branch feature/fast-forwarded'), -1)
-    assert.notEqual(output.indexOf('Not all branches are removed:'), -1)
-    assert.notEqual(output.indexOf('- no-ff'), -1)
+    assert.notEqual(output.indexOf('Not all branches were removed:'), -1)
+    assert.notEqual(output.indexOf(' no-ff'), -1)
 }
 
 const testing_force = () => {
-    const output = child_process.execFileSync('node', [bin, '--force', '--prune'], {
+    const output = child_process.execFileSync('node', [bin, '--prune-all', '--force'], {
         cwd: workingDir,
         encoding: 'utf8',
     })

--- a/src/test.ts
+++ b/src/test.ts
@@ -13,9 +13,11 @@ const __dirname = path.dirname(__filename)
 
 const bin = path.join(__dirname, '../dist/index.js')
 
-// console.log(`Args: ${process.argv[2]?.split('=')[1]}`)
+const isCI = process.argv[3]?.split('=')[1] === 'true'
 
-let tempdir: string = process.argv[2]?.split('=')[1] || ''
+console.log(`isCI: ${isCI}`)
+
+let tempdir: string = process.argv[3]?.split('=')[1] || ''
 let bareDir: string
 let workingDir: string
 
@@ -24,6 +26,12 @@ const setup = () => {
         const tmp = os.tmpdir()
         tempdir = mkdtempSync(tmp + path.sep + 'git-removed-branches-')
     }
+
+    if (isCI) {
+        child_process.execSync('git config --global user.email "you@example.com"', { cwd: tempdir })
+        child_process.execSync('git config --global user.name "Your Name"', { cwd: tempdir })
+    }
+
     bareDir = tempdir + path.sep + 'bare'
     workingDir = tempdir + path.sep + 'working'
 


### PR DESCRIPTION
* Removes option `--prune` from the forked package; removing branches is the default behavior of this version
* New option `--dry-run`: will not actually remove any branches, no matter what options are chosen from the prompts
* New option `--prune-all`: will remove all branches without prompting and without confirmation
    * this is mostly for the tests since I don't currently have a testing framework in place that can deal with the prompts
* Fixed tests on the CI